### PR TITLE
client: Fix docstring

### DIFF
--- a/src/main/python/antidotedb/antidoteclient.py
+++ b/src/main/python/antidotedb/antidoteclient.py
@@ -493,7 +493,7 @@ class Key :
             self.data_type_name = data_type
    
 class StaticTransaction :
-    """" Class for an interative transaction """
+    """" Class for an static transaction """
     def __init__(self, clt, red_blue):
         self.antidoteClient = clt
         self.red_blue = red_blue


### PR DESCRIPTION
There was a class named `InteractiveTransaction` which also had the same docstring, so I though maybe this was a typo.